### PR TITLE
prevent duplicates in chatrooms

### DIFF
--- a/chat/views.py
+++ b/chat/views.py
@@ -3,7 +3,7 @@
 #& https://channels.readthedocs.io/en/latest/tutorial/part_2.html
 from django.shortcuts import render
 
-rooms = []
+rooms = set()
 
 def index(request):
     return render(request, 'chat/index.html', {'rooms': rooms})
@@ -11,5 +11,5 @@ def index(request):
 def room(request, room_name):
     current_user = str(request.user)
     args = {'room_name': room_name}
-    rooms.append(room_name)
+    rooms.add(room_name)
     return render(request, 'chat/room.html', args)


### PR DESCRIPTION
No longer able to accidentally create multiple chat rooms with the same name does not prevent a user from trying to create with the same name. Turns out working with data structures and passing it from HTML to Javascript was not simple; maybe a problem for a different day.